### PR TITLE
Add Region type

### DIFF
--- a/WebApp/processing/processing.go
+++ b/WebApp/processing/processing.go
@@ -82,11 +82,11 @@ func SimplifyImage(img image.Image) (result image.Image, regionCount int) {
 
 	// colors := []color.Color{Black, Red, Green, Blue}
 	for region := range regionMap.GetRegions() {
-		regionPixels := regionMap.GetRegionPixels(RegionIndex(region))
+		region := regionMap.GetRegion(RegionIndex(region))
 		// randColor := color.NRGBA{uint8(rand.Intn(256)), uint8(rand.Intn(256)), uint8(rand.Intn(256)), uint8(255)}
 		// randColor := colors[rand.Intn(len(colors))]
-		if len(regionPixels) < MINIMUM_NUMBER_OF_PIXELS_FOR_VALID_REGION {
-			for _, pixel := range regionPixels {
+		if len(region) < MINIMUM_NUMBER_OF_PIXELS_FOR_VALID_REGION {
+			for _, pixel := range region {
 				newImg.Set(int(pixel.X), int(pixel.Y), White)
 			}
 		} else {

--- a/WebApp/processing/regions.go
+++ b/WebApp/processing/regions.go
@@ -6,7 +6,7 @@ import (
 )
 
 func BuildRegionMap(img image.Image) *RegionMap {
-	regionMap := RegionMap{make([]*[]Pixel, 0, 20), make(map[Pixel]RegionIndex, (img.Bounds().Dx()*img.Bounds().Dy())/4)}
+	regionMap := RegionMap{make([]*Region, 0, 20), make(map[Pixel]RegionIndex, (img.Bounds().Dx()*img.Bounds().Dy())/4)}
 
 	bd := img.Bounds()
 
@@ -27,16 +27,18 @@ func BuildRegionMap(img image.Image) *RegionMap {
 type Pixel struct {
 	X, Y uint16
 }
+
 type RegionIndex int
+type Region []Pixel
 
 type RegionMap struct {
-	regions []*[]Pixel
+	regions []*Region
 	pixels  map[Pixel]RegionIndex
 }
 
 func (rm *RegionMap) NewRegion(pixel Pixel) (region RegionIndex) {
 	region = RegionIndex(len(rm.regions))
-	rm.regions = append(rm.regions, &[]Pixel{pixel})
+	rm.regions = append(rm.regions, &Region{pixel})
 	rm.pixels[pixel] = region
 	return
 }
@@ -61,7 +63,7 @@ func (rm *RegionMap) GetRegionPixels(region RegionIndex) []Pixel {
 	return *rm.regions[region]
 }
 
-func (rm *RegionMap) GetRegions() []*[]Pixel {
+func (rm *RegionMap) GetRegions() []*Region {
 	return rm.regions
 }
 

--- a/WebApp/processing/regions.go
+++ b/WebApp/processing/regions.go
@@ -59,7 +59,7 @@ func (rm *RegionMap) GetRegionOfPixel(pixel Pixel) (regionIndex RegionIndex, has
 	return
 }
 
-func (rm *RegionMap) GetRegionPixels(region RegionIndex) []Pixel {
+func (rm *RegionMap) GetRegion(region RegionIndex) Region {
 	return *rm.regions[region]
 }
 


### PR DESCRIPTION
Adds `Region` type which is an array of Pixels that represents a color region. This does not affect any behavior with region mapping or anything currently, but it should improve code clarity a bit and allow methods to be added to the Region type in the future.