### PR TITLE
Fix dash after images with new sprite

### DIFF
--- a/Game/after_image.gd
+++ b/Game/after_image.gd
@@ -1,10 +1,14 @@
 @icon("res://icons/afterimageicon.png")
 class_name AfterImage extends Sprite2D
 
+var color: Color
+
 func _ready():
 	z_index = -1
+	material = ShaderMaterial.new()
+	material.shader = preload("res://afterimage.gdshader")
+	material.set_shader_parameter("color", color)
 	var tween := create_tween()
-	var new_color = Color(modulate)
-	new_color.a = 0
-	tween.tween_property(self, "modulate", new_color, 0.5)
+	modulate = Color(1, 1, 1, 0.5)
+	tween.tween_property(self, "modulate", Color(1, 1, 1, 0), 0.75)
 	tween.tween_callback(queue_free)

--- a/Game/after_image_emitter.gd
+++ b/Game/after_image_emitter.gd
@@ -23,7 +23,7 @@ func _process(delta):
 			after_image.transform = animated_sprite.global_transform
 			after_image.flip_h = animated_sprite.flip_h
 			after_image.texture_filter = animated_sprite.texture_filter
-			after_image.modulate = random_colors[current_color % len(random_colors)]
+			after_image.color = random_colors[current_color % len(random_colors)]
 			current_color = (current_color + 1) % len(random_colors)
 			
 			get_tree().current_scene.add_child(after_image)

--- a/Game/afterimage.gdshader
+++ b/Game/afterimage.gdshader
@@ -1,0 +1,7 @@
+shader_type canvas_item;
+
+uniform vec3 color;
+
+void fragment() {
+	COLOR.rgba = vec4(color, COLOR.a);
+}

--- a/Game/player.gd
+++ b/Game/player.gd
@@ -89,7 +89,8 @@ func _physics_process(delta):
 	# As good practice, you should replace UI actions with custom gameplay actions.
 	var direction = Input.get_axis("left", "right")
 		
-	if Input.is_action_just_pressed("Dash") and not is_dashing and $dash_cooldown_timer.is_stopped():
+	if Input.is_action_just_pressed("Dash") and not is_dashing \
+		and $dash_cooldown_timer.is_stopped() and not is_on_wall():
 			$dash_timer.start()
 			$dash_cooldown_timer.start()
 			dash_direction = get_direction()
@@ -116,6 +117,7 @@ func _physics_process(delta):
 		last_position_was_wall = true
 		can_jump = true
 		velocity.y = wall_slide_speed
+		$dash_timer.stop()
 		test_animation.play("sliding")
 	
 	if is_dashing and is_on_floor() and is_on_wall():

--- a/Game/player.tscn
+++ b/Game/player.tscn
@@ -363,11 +363,10 @@ scale = Vector2(0.5, 0.5)
 shape = SubResource("RectangleShape2D_3fiya")
 
 [node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
-texture_filter = 3
 position = Vector2(0, 4.76837e-07)
 scale = Vector2(0.127957, 0.127957)
 sprite_frames = SubResource("SpriteFrames_mupna")
-animation = &"sliding"
+animation = &"idle animation"
 autoplay = "new_animation"
 
 [node name="dash_timer" type="Timer" parent="."]

--- a/Game/player.tscn
+++ b/Game/player.tscn
@@ -372,7 +372,7 @@ autoplay = "new_animation"
 
 [node name="dash_timer" type="Timer" parent="."]
 unique_name_in_owner = true
-wait_time = 0.2
+wait_time = 0.15
 one_shot = true
 
 [node name="coyote_timer" type="Timer" parent="."]


### PR DESCRIPTION
## Description
<!-- A description of the changes you made. -->
Makes dash after images appear colored with the new sprite, also prevents you from dashing while on a wall and shortens the dash a bit

## Closed Issues
<!-- Add any issues that this PR closes here. Add the word "Closes" before the issue number. -->
<!-- For example: Closes #123 -->
