### PR TITLE
Boardmesh Options

### DIFF
--- a/Boardbox/file_uploader.gd
+++ b/Boardbox/file_uploader.gd
@@ -5,14 +5,14 @@ var crypto = Crypto.new()
 const filler_chars = "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 var nfiller_chars = filler_chars.length()
 
-func upload_file(url: String, filepath: String, method: HTTPClient.Method, fieldname: String = "file") -> HTTPRequest:
+func upload_file(url: String, filepath: String, method: HTTPClient.Method, fieldname: String = "file", other_fields: Dictionary = {}) -> HTTPRequest:
 	var file_data = FileAccess.get_file_as_bytes(filepath)
 	if file_data.size() <= 0:
 		print(FileAccess.get_open_error())
 		return null
-	return upload_buffer(url, file_data, filepath.get_file(), method, fieldname)
+	return upload_buffer(url, file_data, filepath.get_file(), method, fieldname, other_fields)
 
-func upload_buffer(url: String, buffer: PackedByteArray, filename: String, method: HTTPClient.Method, fieldname: String = "file") -> HTTPRequest:
+func upload_buffer(url: String, buffer: PackedByteArray, filename: String, method: HTTPClient.Method, fieldname: String = "file", other_fields: Dictionary = {}) -> HTTPRequest:
 	var boundary = generate_boundary(16)
 	
 	var extension = filename.get_extension()
@@ -33,6 +33,13 @@ func upload_buffer(url: String, buffer: PackedByteArray, filename: String, metho
 		% [fieldname, filename]).to_utf8_buffer())
 	body.append_array(("\r\nContent-Type: %s\r\n\r\n" % mime_type).to_utf8_buffer())
 	body.append_array(buffer)
+	
+	for k in other_fields:
+		body.append_array("\r\n--".to_utf8_buffer())
+		body.append_array(boundary)
+		body.append_array(("\r\nContent-Disposition: form-data; name=\"%s\"\r\n\r\n%s" \
+			% [k, str(other_fields[k])]).to_utf8_buffer())
+	
 	body.append_array("\r\n--".to_utf8_buffer())
 	body.append_array(boundary)
 	body.append_array("--\r\n".to_utf8_buffer())

--- a/Boardbox/main.gd
+++ b/Boardbox/main.gd
@@ -41,7 +41,7 @@ func create_level(img: Image):
 	loading_indicator.show()
 	loading_indicator.set_text("Uploading Image...")
 	var buffer = img.save_png_to_buffer()
-	var request = FileUploader.upload_buffer(base_url + "/api/build-level", buffer, "image.png", HTTPClient.METHOD_POST, "image")
+	var request = FileUploader.upload_buffer(base_url + "/api/build-level", buffer, "image.png", HTTPClient.METHOD_POST, "image", {"preserveColor": "true"})
 	request.request_completed.connect(_on_response_received)
 
 func _on_response_received(result: int, response_code: int, headers: PackedStringArray, body: PackedByteArray):

--- a/Boardbox/main.gd
+++ b/Boardbox/main.gd
@@ -8,6 +8,10 @@ var base_url = ProjectSettings.get_setting("application/boardbox/web_server_url"
 @onready var error_dialog = $ErrorDialog
 @onready var shape_generator = $ShapeGenerator
 @onready var shapes = $Shapes
+@onready var preserve_color_check = $Buttons/CheckContainer/CheckVBoxContainer/PreserveColorCheck
+@onready var no_color_separation_check = $Buttons/CheckContainer/CheckVBoxContainer/NoColorSeparationCheck
+@onready var allow_white_check = $Buttons/CheckContainer/CheckVBoxContainer/AllowWhiteCheck
+
 
 
 func _on_upload_image_button_pressed():
@@ -41,7 +45,12 @@ func create_level(img: Image):
 	loading_indicator.show()
 	loading_indicator.set_text("Uploading Image...")
 	var buffer = img.save_png_to_buffer()
-	var request = FileUploader.upload_buffer(base_url + "/api/build-level", buffer, "image.png", HTTPClient.METHOD_POST, "image", {"preserveColor": "true"})
+	var request = FileUploader.upload_buffer(base_url + "/api/build-level", buffer, "image.png", \
+		HTTPClient.METHOD_POST, "image", {
+			"preserveColor": preserve_color_check.button_pressed,
+			"noColorSeparation": no_color_separation_check.button_pressed,
+			"allowWhite": allow_white_check.button_pressed,
+		})
 	request.request_completed.connect(_on_response_received)
 
 func _on_response_received(result: int, response_code: int, headers: PackedStringArray, body: PackedByteArray):

--- a/Boardbox/main.tscn
+++ b/Boardbox/main.tscn
@@ -32,22 +32,28 @@ texture_normal = ExtResource("4_vn1tp")
 ignore_texture_size = true
 stretch_mode = 0
 
-[node name="PanelContainer" type="PanelContainer" parent="Buttons"]
+[node name="CheckContainer" type="PanelContainer" parent="Buttons"]
 offset_left = 31.0
 offset_top = 159.0
 offset_right = 281.0
 offset_bottom = 218.0
 
-[node name="VBoxContainer" type="VBoxContainer" parent="Buttons/PanelContainer"]
+[node name="CheckVBoxContainer" type="VBoxContainer" parent="Buttons/CheckContainer"]
 custom_minimum_size = Vector2(250, 0)
 layout_mode = 2
 
-[node name="PreserveColorCheck" type="CheckButton" parent="Buttons/PanelContainer/VBoxContainer"]
+[node name="PreserveColorCheck" type="CheckBox" parent="Buttons/CheckContainer/CheckVBoxContainer"]
 layout_mode = 2
+button_pressed = true
 text = "Preserve Color"
 
-[node name="CheckButton" type="CheckButton" parent="Buttons/PanelContainer/VBoxContainer"]
+[node name="NoColorSeparationCheck" type="CheckBox" parent="Buttons/CheckContainer/CheckVBoxContainer"]
 layout_mode = 2
+text = "No Color Separation"
+
+[node name="AllowWhiteCheck" type="CheckBox" parent="Buttons/CheckContainer/CheckVBoxContainer"]
+layout_mode = 2
+text = "Allow White"
 
 [node name="ShapeGenerator" type="Node" parent="."]
 script = ExtResource("5_ojcst")

--- a/Boardbox/main.tscn
+++ b/Boardbox/main.tscn
@@ -32,6 +32,23 @@ texture_normal = ExtResource("4_vn1tp")
 ignore_texture_size = true
 stretch_mode = 0
 
+[node name="PanelContainer" type="PanelContainer" parent="Buttons"]
+offset_left = 31.0
+offset_top = 159.0
+offset_right = 281.0
+offset_bottom = 218.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Buttons/PanelContainer"]
+custom_minimum_size = Vector2(250, 0)
+layout_mode = 2
+
+[node name="PreserveColorCheck" type="CheckButton" parent="Buttons/PanelContainer/VBoxContainer"]
+layout_mode = 2
+text = "Preserve Color"
+
+[node name="CheckButton" type="CheckButton" parent="Buttons/PanelContainer/VBoxContainer"]
+layout_mode = 2
+
 [node name="ShapeGenerator" type="Node" parent="."]
 script = ExtResource("5_ojcst")
 

--- a/WebApp/app.go
+++ b/WebApp/app.go
@@ -71,7 +71,7 @@ func simplifyImage(c *gin.Context) {
 		return
 	}
 
-	newImg, regionCount, _ := processing.SimplifyImage(img)
+	newImg, regionCount, _ := processing.SimplifyImage(img, processing.RegionMapOptions{NoColorSeparation: false, AllowWhite: false})
 
 	buf := new(bytes.Buffer)
 	if err := png.Encode(buf, newImg); err != nil {
@@ -111,6 +111,8 @@ func buildLevel(c *gin.Context) {
 	}
 
 	preserveColor := c.Request.FormValue("preserveColor")
+	noColorSeparation := c.Request.FormValue("noColorSeparation")
+	allowWhite := c.Request.FormValue("allowWhite")
 
 	contentType := fileh.Header.Get("Content-Type")
 	var img image.Image
@@ -138,7 +140,10 @@ func buildLevel(c *gin.Context) {
 		return
 	}
 
-	newImg, _, regionMap := processing.SimplifyImage(img)
+	newImg, _, regionMap := processing.SimplifyImage(img, processing.RegionMapOptions{
+		NoColorSeparation: noColorSeparation == "true",
+		AllowWhite:        allowWhite == "true",
+	})
 
 	numRegions := len(regionMap.GetRegions())
 	data := make([]RegionData, 0, numRegions)

--- a/WebApp/app.go
+++ b/WebApp/app.go
@@ -110,6 +110,8 @@ func buildLevel(c *gin.Context) {
 		panic(err)
 	}
 
+	preserveColor := c.Request.FormValue("preserveColor")
+
 	contentType := fileh.Header.Get("Content-Type")
 	var img image.Image
 	switch contentType {
@@ -161,8 +163,14 @@ func buildLevel(c *gin.Context) {
 
 		regionImage := image.NewNRGBA(region.GetBounds())
 
-		for j := 0; j < len(region); j++ {
-			regionImage.Set(int(region[j].X), int(region[j].Y), regionColor)
+		if preserveColor == "true" {
+			for j := 0; j < len(region); j++ {
+				regionImage.Set(int(region[j].X), int(region[j].Y), img.At(int(region[j].X), int(region[j].Y)))
+			}
+		} else {
+			for j := 0; j < len(region); j++ {
+				regionImage.Set(int(region[j].X), int(region[j].Y), regionColor)
+			}
 		}
 
 		buf := new(bytes.Buffer)

--- a/WebApp/processing/processing_test.go
+++ b/WebApp/processing/processing_test.go
@@ -15,7 +15,6 @@ import (
 var Cyan color.NRGBA = color.NRGBA{uint8(0), uint8(255), uint8(255), uint8(255)}
 var Magenta color.NRGBA = color.NRGBA{uint8(255), uint8(0), uint8(255), uint8(255)}
 var Yellow color.NRGBA = color.NRGBA{uint8(255), uint8(255), uint8(0), uint8(255)}
-var Blank color.NRGBA = color.NRGBA{uint8(0), uint8(0), uint8(0), uint8(0)}
 
 func generateRegion(img image.Image) *Region {
 	region := make(Region, 0, img.Bounds().Dx()*img.Bounds().Dy())

--- a/WebApp/processing/regions.go
+++ b/WebApp/processing/regions.go
@@ -49,6 +49,7 @@ type RegionMap struct {
 	regions        []*Region
 	pixels         map[Pixel]*RegionIndex
 	regionPointers []*RegionIndex
+	//todo
 }
 
 func (rm *RegionMap) NewRegion(pixel Pixel) (region *RegionIndex) {

--- a/WebApp/processing/regions.go
+++ b/WebApp/processing/regions.go
@@ -6,16 +6,16 @@ import (
 	"slices"
 )
 
-func BuildRegionMap(img image.Image, predicate func(*Region) bool) *RegionMap {
-	regionMap := RegionMap{make([]*Region, 0, 20), make(map[Pixel]*RegionIndex, (img.Bounds().Dx()*img.Bounds().Dy())/4), make([]*RegionIndex, 0)}
+func BuildRegionMap(img image.Image, options RegionMapOptions, predicate func(*Region) bool) *RegionMap {
+	regionMap := RegionMap{make([]*Region, 0, 20), make(map[Pixel]*RegionIndex, (img.Bounds().Dx()*img.Bounds().Dy())/4), make([]*RegionIndex, 0), options}
 
 	bd := img.Bounds()
 
 	for y := bd.Min.Y; y < bd.Max.Y; y++ {
 		for x := bd.Min.X; x < bd.Max.X; x++ {
 			pixel := Pixel{uint16(x), uint16(y)}
-
-			if img.At(x, y) != White {
+			c := img.At(x, y)
+			if c != Blank && (regionMap.options.AllowWhite || c != White) {
 				regionMap.AddPixelToRegionMap(pixel, img)
 			}
 		}
@@ -49,7 +49,11 @@ type RegionMap struct {
 	regions        []*Region
 	pixels         map[Pixel]*RegionIndex
 	regionPointers []*RegionIndex
-	//todo
+	options        RegionMapOptions
+}
+
+type RegionMapOptions struct {
+	NoColorSeparation, AllowWhite bool
 }
 
 func (rm *RegionMap) NewRegion(pixel Pixel) (region *RegionIndex) {
@@ -73,8 +77,8 @@ func (rm *RegionMap) AddPixelToRegionMap(pixel Pixel, img image.Image) {
 	colorLeft := img.At(int(pixel.X)-1, int(pixel.Y))
 	regionAbove, hasRegionAbove := rm.pixels[Pixel{pixel.X, pixel.Y - 1}]
 	colorAbove := img.At(int(pixel.X), int(pixel.Y)-1)
-	if hasRegionLeft && ColorRegionEquivalence(colorP, colorLeft) {
-		if hasRegionAbove && ColorRegionEquivalence(colorP, colorAbove) && *regionLeft != *regionAbove { // time to merge regions
+	if hasRegionLeft && (rm.options.NoColorSeparation || ColorRegionEquivalence(colorP, colorLeft)) {
+		if hasRegionAbove && (rm.options.NoColorSeparation || ColorRegionEquivalence(colorP, colorAbove)) && *regionLeft != *regionAbove { // time to merge regions
 			pixelsInRegionAbove := rm.regions[*regionAbove]
 			// grow left region to fit the above region
 			mergedRegion := slices.Grow(*rm.regions[*regionLeft], len(*rm.regions[*regionLeft])+len(*pixelsInRegionAbove)+1)
@@ -92,7 +96,7 @@ func (rm *RegionMap) AddPixelToRegionMap(pixel Pixel, img image.Image) {
 			*regionAbove = *regionLeft
 		}
 		rm.AddPixelToRegion(pixel, regionLeft)
-	} else if hasRegionAbove && ColorRegionEquivalence(colorP, colorAbove) {
+	} else if hasRegionAbove && (rm.options.NoColorSeparation || ColorRegionEquivalence(colorP, colorAbove)) {
 		rm.AddPixelToRegion(pixel, regionAbove)
 	} else {
 		rm.NewRegion(pixel)


### PR DESCRIPTION
## Description
<!-- A description of the changes you made. -->
Adds new options for how regions should be processed and sent back when making requests to Boardmesh.

The options are as follows:
- **Preserve Color** - Keeps the original color of the image in the regions that are sent back.
- **No Color Separation** - Regions can no longer be separated by color, only empty space.
- **Allow White** - White is no longer considered empty space, only transparent pixels are.